### PR TITLE
Kerbalism update

### DIFF
--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/tanks_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/tanks_kism.cfg
@@ -198,7 +198,7 @@
 		SETUP
 		{
 			name = Oxygen
-			desc = Store liquid oxygen
+			desc = Store pressurized <b>Oxygen</b> gas.
 
 			RESOURCE
 			{
@@ -213,7 +213,7 @@
 		SETUP
 		{
 			name = Nitrogen
-			desc = Store liquid nitrogen
+			desc = Store pressurized <b>Nitrogen</b> gas.
 
 			RESOURCE
 			{
@@ -228,7 +228,7 @@
 		SETUP
 		{
 			name = Hydrogen
-			desc = Store liquid hydrogen
+			desc = Store pressurized <b>Hydrogen</b> gas.
 
 			RESOURCE
 			{
@@ -243,7 +243,7 @@
 		SETUP
 		{
 			name = Ammonia
-			desc = Store liquid ammonia
+			desc = Store pressurized <b>Ammonia</b> gas.
 
 			RESOURCE
 			{
@@ -266,7 +266,7 @@
 	MODULE
 	{
 		name = Configure
-		title = Pressurized Tank
+		title = Waste Tank
 		slots = 1
 
 		SETUP
@@ -306,7 +306,7 @@
 		SETUP
 		{
 			name = Pressurized
-			desc = Store waste gas
+			desc = Store pressurized <b>Carbon dioxide</b> gas.
 
 			RESOURCE
 			{
@@ -321,7 +321,7 @@
 		SETUP
 		{
 			name = Unpressurized
-			desc = Store solid and liquid wastes
+			desc = Store solid and liquid organic <b>Waste</b>.
 
 			RESOURCE
 			{

--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/tanks_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/tanks_kism.cfg
@@ -1,5 +1,5 @@
 //Long tank A
-@PART[dsak_ess_al]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_al]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost = 19100
 	@cost = 1450
@@ -14,7 +14,7 @@
 }
 
 //Long tank B
-@PART[dsak_ess_bl]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_bl]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost = 19100
 	@cost = 1450
@@ -29,7 +29,7 @@
 }
 
 //Short tank A
-@PART[dsak_ess_as]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_as]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost = 19100
 	@cost = 1450
@@ -44,7 +44,7 @@
 }
 
 //Short tank B
-@PART[dsak_ess_bs]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_bs]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost = 19100
 	@cost = 1450
@@ -59,7 +59,7 @@
 }
 
 //Short waste tank
-@PART[dsak_swg_as]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_swg_as]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost = 19100
 	@cost = 1450
@@ -77,7 +77,7 @@
 // Prepare tanks for solid or liquid essentials
 // ============================================================================
 
-@PART[dsak_ess_al,dsak_ess_as]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_al,dsak_ess_as]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	MODULE
 	{
@@ -187,7 +187,7 @@
 // Prepare tanks for pressurized essentials
 // ============================================================================
 
-@PART[dsak_ess_bl,dsak_ess_bs]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_bl,dsak_ess_bs]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	MODULE
 	{
@@ -261,7 +261,7 @@
 // Prepare sewage tank
 // ============================================================================
 
-@PART[dsak_swg_as]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_swg_as]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	MODULE
 	{

--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/tanks_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/tanks_kism.cfg
@@ -254,6 +254,37 @@
 				@maxAmount *= #$../../../ContainerVolume$
 			}
 		}
+
+		SETUP
+		{
+			name = CarbonDioxide
+			desc = Store pressurized <b>Carbon dioxide</b> gas.
+
+			RESOURCE
+			{
+				name = CarbonDioxide
+				amount = 601.36
+				maxAmount = 601.36
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Xenon Gas
+			desc = Store pressurized <b>Xenon</b> gas.
+			tech = ionPropulsion
+
+			RESOURCE
+			{
+				name = XenonGas
+				amount = 836.26
+				maxAmount = 836.26
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+		}
 	}
 }
 

--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
@@ -255,8 +255,32 @@
 	MODULE
 	{
 		name = ProcessController
+		resource = _WaterElectrolysisO2Priority
+		title = Water electrolysis oxygen priority
+		capacity = 4.29
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterElectrolysisH2Priority
+		title = Water electrolysis hydrogen priority
+		capacity = 4.29
+	}
+
+	MODULE
+	{
+		name = ProcessController
 		resource = _Sabatier
-		title = Sabatier process
+		title = Sabatier process LF priority
+		capacity = 4.29
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _SabatierH2OPriority
+		title = Sabatier process water priority
 		capacity = 4.29
 	}
 
@@ -318,6 +342,14 @@
 
 	MODULE
 	{
+		name = ProcessController
+		resource = _SCO
+		title = SCO
+		capacity = 4.29
+	}
+
+	MODULE
+	{
 		name = Configure
 		title = Chemical Plant
 		slots = 1
@@ -337,13 +369,53 @@
 
 		SETUP
 		{
-			name = Sabatier Process
+			name = Water Electrolysis (O2 priority)
+			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components. If necessary Hydrogen will be vented in order to continue the Oxygen extraction.
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterElectrolysisO2Priority
+			}
+		}
+
+		SETUP
+		{
+			name = Water Electrolysis (H2 priority)
+			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components. If necessary Oxygen will be vented in order to continue the Hydrogen extraction.
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterElectrolysisH2Priority
+			}
+		}
+
+		SETUP
+		{
+			name = Sabatier Process (LF priority)
+			desc = <b>Hydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LiquidFuel</b>. If needed Water will be vented in order to continue the LiquidFuel extraction.
 
 			MODULE
 			{
 				type = ProcessController
 				id_field = resource
 				id_value = _Sabatier
+			}
+		}
+
+		SETUP
+		{
+			name = Sabatier Process (H2O priority)
+			desc = <b>Hydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LiquidFuel</b>. If needed LiquidFuel will be vented in order to continue the Water extraction.
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _SabatierH2OPriority
 			}
 		}
 
@@ -441,6 +513,20 @@
 				type = ProcessController
 				id_field = resource
 				id_value = _MRE
+			}
+		}
+
+		SETUP
+		{
+			name = Selective Catalytic Oxidation
+			desc = <b>Ammonia</b> and <b>Oxygen</b> react with a hydrotalcite-like catalyst to produce <b>Nitrogen</b> and <b>Water</b>.
+			tech = experimentalScience
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _SCO
 			}
 		}
 

--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
@@ -69,37 +69,49 @@
 	MODULE
 	{
 		name = Greenhouse
-		// name of resource produced by harvests
-		crop_resource = Food
-		// amount of resource produced by harvests, 30% standard harvest size
-		crop_size = 198.135
-		// growth per-second when all conditions apply, 2.2x fast for 90 day growth cycle. who says you can't grow fast food?
-		crop_rate = 0.0000005144
-		// EC/s consumed by the lamp at max intensity, only 25% savings on EC/s versus its < 25% volume
-		ec_rate = 1.875
 
-		// minimum lighting flux required for growth, in W/m^2
-		light_tolerance = 400.0
-		// minimum pressure required for growth, in sea level atmospheres
-		pressure_tolerance = 0.1
-		// maximum radiation allowed for growth in rad/s, considered after shielding is applied
-		radiation_tolerance = 0.000008333
+		crop_resource = Food                // name of resource produced by harvests
+		crop_size = 151.35                  // amount of resource produced by harvests, 23% of standard crop size, volume of 5.5m^3
+		crop_rate = 0.0000005144           // growth per-second when all conditions apply, 2.2x faster for 90 day growth cycle. who says you can't grow fast food?
+		ec_rate = 0.57                      // EC/s consumed by the lamp at max intensity
+
+		light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
+		pressure_tolerance = 0.1            // minimum pressure required for growth, in sea level atmospheres
+		radiation_tolerance = 0.000008333   // maximum radiation allowed for growth in rad/s, considered after shielding is applied
 
 		INPUT_RESOURCE
 		{
-			name = CarbonDioxide
-			rate = 0.02782
+			name = Ammonia
+			rate = 0.0005248                // 15 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 15 * crop_size
 		}
+
 		INPUT_RESOURCE
 		{
 			name = Water
-			rate = 0.0000955
-			// 25% more Water
+			rate = 0.000017509              // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
 		}
+
+		INPUT_RESOURCE
+		{
+			name = WasteAtmosphere          // Plants work on WasteAtmosphere and replace a scrubber, if not enough WasteAtmosphere exists then CO2 is used
+			rate = 0.0046294                // Matched to a Kerbals WasteAtmosphere output which is 75% of required CO2 for crops
+		}
+
+		INPUT_RESOURCE
+		{
+			name = CarbonDioxide            // Kerbals don't provide enough WasteAtmosphere for their required food production. If excess WasteAtmosphere is
+                                            // present then it will be used in place of CO2 injection
+			rate = 0.00115735               // Remaining 25% of CO2 required.
+		}
+
+		// Note. if there is a deficiency in the amount of WasteAtmosphere needed then the missing amount of WasteAtmosphere will be added to the
+		// CarbonDioxide input and Vies Versa if not enough CarbonDioxide is present and there is extra WasteAtmosphere.
+		// If there is not enough resources then the plants will suffer.
+
 		OUTPUT_RESOURCE
 		{
 			name = Oxygen
-			rate = 0.02758
+			rate = 0.00632042
 		}
 	}
 
@@ -120,35 +132,32 @@
 
 	RESOURCE
 	{
-		name = Waste
-		amount = 0
-		maxAmount = 10
-	}
-	RESOURCE
-	{
 		name = Ammonia
-		amount = 200
-		maxAmount = 200
+		amount = 1550
+		maxAmount = 1550
 	}
+
+	// CarbonDioxide is provided because humans don't provide enough CO2 for their required food production
 	RESOURCE
 	{
 		name = CarbonDioxide
-		amount = 2000
-		maxAmount = 2000
+		amount = 14200
+		maxAmount = 14200
 	}
+
 	// To support the pressure control
 	RESOURCE
 	{
 		name = Nitrogen
-		amount = 2000
-		maxAmount = 2000
+		amount = 3600
+		maxAmount = 3600
 	}
 
 	RESOURCE
 	{
 		name = Water
-		amount = 10
-		maxAmount = 10
+		amount = 60
+		maxAmount = 60
 	}
 }
 

--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
@@ -1,5 +1,5 @@
 //Cabin short: Comforts
-@PART[dsak_cabin]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_cabin]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	//@entryCost = 12000
 	@cost = 6400
@@ -26,7 +26,7 @@
 }
 
 //Cabin long: Comforts
-@PART[dsak_cabin2]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_cabin2]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	//@entryCost = 15000
 	@cost = 7200
@@ -52,8 +52,8 @@
 	}
 }
 
-//Processor A: Greenhouse
-@PART[dsak_proc_a]:NEEDS[Kerbalism,ProfileDefault]
+//Processor A: Hydroponics/Greenhouse
+@PART[dsak_proc_a]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost = 18300
 	@cost = 2270
@@ -153,7 +153,7 @@
 }
 
 //Processor B: Fuel Cell
-@PART[dsak_proc_b]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_proc_b]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost = 13300
 	@cost = 3310
@@ -188,7 +188,7 @@
 }
 
 //Processor C: Chemical Plant (ISRU)
-@PART[dsak_proc_c]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_proc_c]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost = 6000
 	@cost = 3900

--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
@@ -170,8 +170,50 @@
 	{
 		name = ProcessController
 		resource = _FuelCell
-		title = Fuel cell
+		title = H2+O2 fuel cell
 		capacity = 15
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _MonopropFuelCell
+		title = Monoprop+O2 fuel cell
+		capacity = 75
+	}
+
+	MODULE
+	{
+		name = Configure
+		title = Fuel Cell
+		slots = 1
+
+		SETUP
+		{
+			name = Hydrogen Oxygen Fuel Cell
+			desc = Burns <b>Hydrogen</b> gas and <b>Oxygen</b> gas, producing <b>Water</b> as a by-product.
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _FuelCell
+			}
+		}
+
+		SETUP
+		{
+			name = Monoprop Oxygen Fuel Cell
+			desc = Burns <b>MonoPropellant</b> and <b>Oxygen</b> gas, producing <b>Water</b> and <b>Nitrogen</b> gas as by-products.
+			tech = advElectrics
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _MonopropFuelCell
+			}
+		}
 	}
 
 	MODULE:NEEDS[FeatureReliability]

--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
@@ -283,6 +283,7 @@
 		SETUP
 		{
 			name = Water Electrolysis
+			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components.
 
 			MODULE
 			{
@@ -307,6 +308,7 @@
 		SETUP
 		{
 			name = Haber Process
+			desc = Produce <b>Ammonia</b> by <b>Nitrogen</b> fixation.
 
 			MODULE
 			{
@@ -319,7 +321,7 @@
 		SETUP
 		{
 			name = Waste Incinerator
-			desc = Produce <b>CarbonDioxide</b> by combustion of <b>Waste</b>. Include a small exhaust turbine generator.
+			desc = Produce <b>CarbonDioxide</b> by combustion of <b>Waste</b> with <b>Oxygen</b>. Includes a small exhaust turbine generator.
 			tech = precisionEngineering
 
 			MODULE
@@ -347,6 +349,7 @@
 		SETUP
 		{
 			name = Anthraquinone Process
+			desc = Synthesize <b>Oxidizer</b> using a redox of <b>Oxygen</b> and <b>Hydrogen</b>.
 			tech = advScienceTech
 
 			MODULE
@@ -360,6 +363,7 @@
 		SETUP
 		{
 			name = Hydrazine Production
+			desc = <b>Oxidizer</b> and <b>Ammonia</b> react to produce <b>MonoPropellant</b> and <b>Water</b>.
 			tech = advScienceTech
 
 			MODULE

--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
@@ -72,8 +72,8 @@
 
 		crop_resource = Food                // name of resource produced by harvests
 		crop_size = 151.35                  // amount of resource produced by harvests, 23% of standard crop size, volume of 5.5m^3
-		crop_rate = 0.0000005144           // growth per-second when all conditions apply, 2.2x faster for 90 day growth cycle. who says you can't grow fast food?
-		ec_rate = 0.57                      // EC/s consumed by the lamp at max intensity
+		crop_rate = 0.0000005144            // growth per-second when all conditions apply, 2.2x faster for 90 day growth cycle. who says you can't grow fast food?
+		ec_rate = 1.778                     // EC/s consumed by the lamp at max intensity *2.2 Wendy's bonus + 40% extra
 
 		light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
 		pressure_tolerance = 0.1            // minimum pressure required for growth, in sea level atmospheres
@@ -82,26 +82,26 @@
 		INPUT_RESOURCE
 		{
 			name = Ammonia
-			rate = 0.0005248                // 15 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 15 * crop_size
+			rate = 0.00116623               // 15 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate *2.2 == 15 * crop_size *2.2 Wendy's bonus
 		}
 
 		INPUT_RESOURCE
 		{
 			name = Water
-			rate = 0.000017509              // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
+			rate = 0.000038909              // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate *2.2 == 0.5 * crop_size *2.2 Wendy's bonus
 		}
 
 		INPUT_RESOURCE
 		{
 			name = WasteAtmosphere          // Plants work on WasteAtmosphere and replace a scrubber, if not enough WasteAtmosphere exists then CO2 is used
-			rate = 0.0046294                // Matched to a Kerbals WasteAtmosphere output which is 75% of required CO2 for crops
+			rate = 0.0102876                // Matched to a Kerbals WasteAtmosphere output which is 75% of required CO2 for crops *2.2 Wendy's bonus
 		}
 
 		INPUT_RESOURCE
 		{
 			name = CarbonDioxide            // Kerbals don't provide enough WasteAtmosphere for their required food production. If excess WasteAtmosphere is
                                             // present then it will be used in place of CO2 injection
-			rate = 0.00115735               // Remaining 25% of CO2 required.
+			rate = 0.00257189               // Remaining 25% of CO2 required *2.2 Wendy's bonus.
 		}
 
 		// Note. if there is a deficiency in the amount of WasteAtmosphere needed then the missing amount of WasteAtmosphere will be added to the
@@ -111,7 +111,7 @@
 		OUTPUT_RESOURCE
 		{
 			name = Oxygen
-			rate = 0.00632042
+			rate = 0.01404538               // *2.2 Wendy's bonus
 		}
 	}
 
@@ -126,31 +126,31 @@
 	RESOURCE
 	{
 		name = Ammonia
-		amount = 1550
-		maxAmount = 1550
+		amount = 3750
+		maxAmount = 3750
 	}
 
 	// CarbonDioxide is provided because humans don't provide enough CO2 for their required food production
 	RESOURCE
 	{
 		name = CarbonDioxide
-		amount = 14200
-		maxAmount = 14200
+		amount = 36000
+		maxAmount = 36000
 	}
 
 	// To support the pressure control
 	RESOURCE
 	{
 		name = Nitrogen
-		amount = 3600
-		maxAmount = 3600
+		amount = 3800
+		maxAmount = 3800
 	}
 
 	RESOURCE
 	{
 		name = Water
-		amount = 60
-		maxAmount = 60
+		amount = 140
+		maxAmount = 140
 	}
 }
 

--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
@@ -119,15 +119,8 @@
 	{
 		name = Habitat
 		toggle = false
-	}
-
-	MODULE
-	{
-		name = ProcessController
-		resource = _PressureControl
-		title = Pressure control
-		capacity = 0.2143
-		running = true
+		volume = 7              // The Greenhouse has 5.5 m^3 volume dedicated to food production plus 1.5 for Kerbals working space
+		surface = 5.4
 	}
 
 	RESOURCE

--- a/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk2/utils_kism.cfg
@@ -354,6 +354,16 @@
 		title = Chemical Plant
 		slots = 1
 
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = Upgrade-Slots
+				techRequired__ = electronics
+				slots = 0
+			}
+		}
+
 		SETUP
 		{
 			name = Water Electrolysis
@@ -541,4 +551,10 @@
 			extra_mass = 0.2
 		}
 	}
+}
+
+// Processor C: Chemical Plant (ISRU) slot upgrade
+@PART[dsak_proc_c]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
+{ @MODULE[Configure] { @UPGRADES { @UPGRADE { @slots = #$../../slots$
+      @slots += 1 } } }
 }

--- a/GameData/DeepSky/AirlineKuisine/ModesMk3/tanks_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk3/tanks_kism.cfg
@@ -258,6 +258,37 @@
 				@maxAmount *= #$../../../ContainerVolume$
 			}
 		}
+
+		SETUP
+		{
+			name = CarbonDioxide
+			desc = Store pressurized <b>Carbon dioxide</b> gas.
+
+			RESOURCE
+			{
+				name = CarbonDioxide
+				amount = 601.36
+				maxAmount = 601.36
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Xenon Gas
+			desc = Store pressurized <b>Xenon</b> gas.
+			tech = ionPropulsion
+
+			RESOURCE
+			{
+				name = XenonGas
+				amount = 836.26
+				maxAmount = 836.26
+				@amount *= #$../../../ContainerVolume$
+				@maxAmount *= #$../../../ContainerVolume$
+			}
+		}
 	}
 }
 

--- a/GameData/DeepSky/AirlineKuisine/ModesMk3/tanks_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk3/tanks_kism.cfg
@@ -1,5 +1,5 @@
 //Medium Tank
-@PART[dsak_ess_3a]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_3a]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost *= 1.2
 	@cost *= 1.6
@@ -12,7 +12,7 @@
 	ContainerVolume = 23984
 }
 //Short Tank
-@PART[dsak_ess_3as]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_3as]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost *= 1.2
 	@cost *= 1.6
@@ -25,7 +25,7 @@
 	ContainerVolume = 11992
 }
 //Tiny Tank
-@PART[dsak_ess_3at]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_3at]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost *= 1.2
 	@cost *= 1.9
@@ -39,7 +39,7 @@
 	ContainerVolume = 6236
 }
 //Waste Tank
-@PART[dsak_swg_3at]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_swg_3at]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost *= 1.2
 	@cost *= 1.7
@@ -56,7 +56,7 @@
 // Prepare tanks for solid or liquid essentials
 // ============================================================================
 
-@PART[dsak_ess_3a,dsak_ess_3as]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_3a,dsak_ess_3as]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	MODULE
 	{
@@ -191,7 +191,7 @@
 // Prepare tanks for pressurized essentials
 // ============================================================================
 
-@PART[dsak_ess_3at]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_ess_3at]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	MODULE
 	{
@@ -265,7 +265,7 @@
 // Prepare sewage tank
 // ============================================================================
 
-@PART[dsak_swg_3at]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_swg_3at]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	MODULE
 	{

--- a/GameData/DeepSky/AirlineKuisine/ModesMk3/tanks_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk3/tanks_kism.cfg
@@ -61,7 +61,7 @@
 	MODULE
 	{
 		name = Configure
-		title = Variety Container
+		title = Supply Container
 		slots = 1
 
 		SETUP
@@ -202,7 +202,7 @@
 		SETUP
 		{
 			name = Oxygen
-			desc = Store liquid oxygen
+			desc = Store pressurized <b>Oxygen</b> gas.
 
 			RESOURCE
 			{
@@ -217,7 +217,7 @@
 		SETUP
 		{
 			name = Nitrogen
-			desc = Store liquid nitrogen
+			desc = Store pressurized <b>Nitrogen</b> gas.
 
 			RESOURCE
 			{
@@ -232,7 +232,7 @@
 		SETUP
 		{
 			name = Hydrogen
-			desc = Store liquid hydrogen
+			desc = Store pressurized <b>Hydrogen</b> gas.
 
 			RESOURCE
 			{
@@ -247,7 +247,7 @@
 		SETUP
 		{
 			name = Ammonia
-			desc = Store liquid ammonia
+			desc = Store pressurized <b>Ammonia</b> gas.
 
 			RESOURCE
 			{
@@ -270,7 +270,7 @@
 	MODULE
 	{
 		name = Configure
-		title = Pressurized Tank
+		title = Waste Tank
 		slots = 1
 
 		SETUP
@@ -310,7 +310,7 @@
 		SETUP
 		{
 			name = Pressurized
-			desc = Store waste gas
+			desc = Store pressurized <b>Carbon dioxide</b> gas.
 
 			RESOURCE
 			{
@@ -325,7 +325,7 @@
 		SETUP
 		{
 			name = Unpressurized
-			desc = Store solid and liquid wastes
+			desc = Store solid and liquid organic <b>Waste</b>.
 
 			RESOURCE
 			{

--- a/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
@@ -315,6 +315,16 @@
 		title = Chemical Plant
 		slots = 1
 
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = Upgrade-Slots
+				techRequired__ = electronics
+				slots = 0
+			}
+		}
+
 		SETUP
 		{
 			name = Water Electrolysis
@@ -502,4 +512,10 @@
 			extra_mass = 0.2
 		}
 	}
+}
+
+// Processor C: Chemical Plant (ISRU) slot upgrade
+@PART[dsak_proc_3c]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
+{ @MODULE[Configure] { @UPGRADES { @UPGRADE { @slots = #$../../slots$
+      @slots += 1 } } }
 }

--- a/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
@@ -216,8 +216,32 @@
 	MODULE
 	{
 		name = ProcessController
+		resource = _WaterElectrolysisO2Priority
+		title = Water electrolysis oxygen priority
+		capacity = 18.4
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterElectrolysisH2Priority
+		title = Water electrolysis hydrogen priority
+		capacity = 18.4
+	}
+
+	MODULE
+	{
+		name = ProcessController
 		resource = _Sabatier
-		title = Sabatier process
+		title = Sabatier process LF priority
+		capacity = 18.4
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _SabatierH2OPriority
+		title = Sabatier process water priority
 		capacity = 18.4
 	}
 
@@ -279,6 +303,14 @@
 
 	MODULE
 	{
+		name = ProcessController
+		resource = _SCO
+		title = SCO
+		capacity = 18.4
+	}
+
+	MODULE
+	{
 		name = Configure
 		title = Chemical Plant
 		slots = 1
@@ -298,13 +330,53 @@
 
 		SETUP
 		{
-			name = Sabatier Process
+			name = Water Electrolysis (O2 priority)
+			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components. If necessary Hydrogen will be vented in order to continue the Oxygen extraction.
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterElectrolysisO2Priority
+			}
+		}
+
+		SETUP
+		{
+			name = Water Electrolysis (H2 priority)
+			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components. If necessary Oxygen will be vented in order to continue the Hydrogen extraction.
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterElectrolysisH2Priority
+			}
+		}
+
+		SETUP
+		{
+			name = Sabatier Process (LF priority)
+			desc = <b>Hydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LiquidFuel</b>. If needed Water will be vented in order to continue the LiquidFuel extraction.
 
 			MODULE
 			{
 				type = ProcessController
 				id_field = resource
 				id_value = _Sabatier
+			}
+		}
+
+		SETUP
+		{
+			name = Sabatier Process (H2O priority)
+			desc = <b>Hydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LiquidFuel</b>. If needed LiquidFuel will be vented in order to continue the Water extraction.
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _SabatierH2OPriority
 			}
 		}
 
@@ -402,6 +474,20 @@
 				type = ProcessController
 				id_field = resource
 				id_value = _MRE
+			}
+		}
+
+		SETUP
+		{
+			name = Selective Catalytic Oxidation
+			desc = <b>Ammonia</b> and <b>Oxygen</b> react with a hydrotalcite-like catalyst to produce <b>Nitrogen</b> and <b>Water</b>.
+			tech = experimentalScience
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _SCO
 			}
 		}
 

--- a/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
@@ -132,8 +132,50 @@
 	{
 		name = ProcessController
 		resource = _FuelCell
-		title = Fuel cell
+		title = H2+O2 fuel cell
 		capacity = 65
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _MonopropFuelCell
+		title = Monoprop+O2 fuel cell
+		capacity = 325
+	}
+
+	MODULE
+	{
+		name = Configure
+		title = Fuel Cell
+		slots = 1
+
+		SETUP
+		{
+			name = Hydrogen Oxygen Fuel Cell
+			desc = Burns <b>Hydrogen</b> gas and <b>Oxygen</b> gas, producing <b>Water</b> as a by-product.
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _FuelCell
+			}
+		}
+
+		SETUP
+		{
+			name = Monoprop Oxygen Fuel Cell
+			desc = Burns <b>MonoPropellant</b> and <b>Oxygen</b> gas, producing <b>Water</b> and <b>Nitrogen</b> gas as by-products.
+			tech = advElectrics
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _MonopropFuelCell
+			}
+		}
 	}
 
 	MODULE:NEEDS[FeatureReliability]

--- a/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
@@ -34,35 +34,49 @@
 	MODULE
 	{
 		name = Greenhouse
-		// name of resource produced by harvests
-		crop_resource = Food
-		// amount of resource produced by harvests
-		crop_size = 660.45
-		// growth per-second when all conditions apply
-		crop_rate = 0.00000023148
-		// EC/s consumed by the lamp at max intensity
-		ec_rate = 2.5
 
-		// minimum lighting flux required for growth, in W/m^2
-		light_tolerance = 400.0
-		// minimum pressure required for growth, in sea level atmospheres
-		pressure_tolerance = 0.1
-		// maximum radiation allowed for growth in rad/s, considered after shielding is applied
-		radiation_tolerance = 0.000008333
+		crop_resource = Food                // name of resource produced by harvests
+		crop_size = 660.45                  // amount of resource produced by harvests
+		crop_rate = 0.00000023148           // growth per-second when all conditions apply
+		ec_rate = 2.5                       // EC/s consumed by the lamp at max intensity
+
+		light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
+		pressure_tolerance = 0.1            // minimum pressure required for growth, in sea level atmospheres
+		radiation_tolerance = 0.000008333   // maximum radiation allowed for growth in rad/s, considered after shielding is applied
+
 		INPUT_RESOURCE
 		{
-			name = CarbonDioxide
-			rate = 0.02782
+			name = Ammonia
+			rate = 0.00229                  // 15 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 15 * crop_size
 		}
+
 		INPUT_RESOURCE
 		{
 			name = Water
-			rate = 0.0000764
+			rate = 0.0000764                // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
 		}
+
+		INPUT_RESOURCE
+		{
+			name = WasteAtmosphere          // Plants work on WasteAtmosphere and replace a scrubber, if not enough WasteAtmosphere exists then CO2 is used
+			rate = 0.020201                 // Matched to a Kerbals WasteAtmosphere output which is 75% of required CO2 for crops
+		}
+
+		INPUT_RESOURCE
+		{
+			name = CarbonDioxide            // Kerbals don't provide enough WasteAtmosphere for their required food production. If excess WasteAtmosphere is
+                                            // present then it will be used in place of CO2 injection
+			rate = 0.00505025               // Remaining 25% of CO2 required.
+		}
+
+		// Note. if there is a deficiency in the amount of WasteAtmosphere needed then the missing amount of WasteAtmosphere will be added to the
+		// CarbonDioxide input and Vies Versa if not enough CarbonDioxide is present and there is extra WasteAtmosphere.
+		// If there is not enough resources then the plants will suffer.
+
 		OUTPUT_RESOURCE
 		{
 			name = Oxygen
-			rate = 0.02758
+			rate = 0.02758                   // 100% of oxygen required by 1 crew member, based on Prototype Lunar Greenhouse design targets
 		}
 	}
 
@@ -70,6 +84,8 @@
 	{
 		name = Habitat
 		toggle = false
+		volume = 30          // The Greenhouse has 24 m^3 volume dedicated to food production plus 6 for Kerbals working space
+		surface = 14.2
 	}
 
 	MODULE
@@ -83,34 +99,32 @@
 
 	RESOURCE
 	{
-		name = Waste
-		amount = 0
-		maxAmount = 10
-	}
-	RESOURCE
-	{
 		name = Ammonia
-		amount = 1000
-		maxAmount = 1000
+		amount = 7100            // enough for 206.5 days including reclaimed ammonia from wastes, one crop cycle, two greenhouses combined
+		maxAmount = 7100
 	}
+
+	// CarbonDioxide is provided because humans don't provide enough CO2 for their required food production
 	RESOURCE
 	{
 		name = CarbonDioxide
-		amount = 10000
-		maxAmount = 10000
+		amount = 67000           // enough for 204.5 days of CO2 injection (25% of total CO2 required), one crop cycle, two greenhouses combined
+		maxAmount = 67000
 	}
+
 	// To support the pressure control
 	RESOURCE
 	{
 		name = Nitrogen
-		amount = 10000
+		amount = 10000           // enough for 219 days , one crop cycle + 15 days 4 hrs
 		maxAmount = 10000
 	}
+
 	RESOURCE
 	{
 		name = Water
-		amount = 50
-		maxAmount = 50
+		amount = 250             // enough for 205 days including reclaimed water from wastes and humidity, one crop cycle, two greenhouses combined
+		maxAmount = 250
 	}
 }
 

--- a/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
@@ -1,5 +1,5 @@
 //Cabin huge: Comforts
-@PART[dsak_cabin3]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_cabin3]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost *= 1.2
 	@cost *= 1.25
@@ -17,8 +17,8 @@
 	}
 }
 
-//Processor A: Agroponics/Greenhouse
-@PART[dsak_proc_3a]:NEEDS[Kerbalism,ProfileDefault]
+//Processor A: Hydroponics/Greenhouse
+@PART[dsak_proc_3a]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost *= 1.6
 	@cost *= 2.2
@@ -115,7 +115,7 @@
 }
 
 //Processor B: Fuel Cell
-@PART[dsak_proc_3b]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_proc_3b]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost *= 1.2
 	@cost *= 1.4
@@ -150,7 +150,7 @@
 }
 
 //Processor C: Chemical Plant (ISRU)
-@PART[dsak_proc_3c]:NEEDS[Kerbalism,ProfileDefault]
+@PART[dsak_proc_3c]:NEEDS[Kerbalism,ProfileDefault]:FOR[AirlineKuisine]
 {
 	@entryCost *= 1.2
 	@cost *= 1.8

--- a/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
+++ b/GameData/DeepSky/AirlineKuisine/ModesMk3/utils_kism.cfg
@@ -244,6 +244,7 @@
 		SETUP
 		{
 			name = Water Electrolysis
+			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components.
 
 			MODULE
 			{
@@ -268,6 +269,7 @@
 		SETUP
 		{
 			name = Haber Process
+			desc = Produce <b>Ammonia</b> by <b>Nitrogen</b> fixation.
 
 			MODULE
 			{
@@ -280,7 +282,7 @@
 		SETUP
 		{
 			name = Waste Incinerator
-			desc = Produce <b>CarbonDioxide</b> by combustion of <b>Waste</b>. Include a small exhaust turbine generator.
+			desc = Produce <b>CarbonDioxide</b> by combustion of <b>Waste</b> with <b>Oxygen</b>. Includes a small exhaust turbine generator.
 			tech = precisionEngineering
 
 			MODULE
@@ -308,6 +310,7 @@
 		SETUP
 		{
 			name = Anthraquinone Process
+			desc = Synthesize <b>Oxidizer</b> using a redox of <b>Oxygen</b> and <b>Hydrogen</b>.
 			tech = advScienceTech
 
 			MODULE
@@ -321,6 +324,7 @@
 		SETUP
 		{
 			name = Hydrazine Production
+			desc = <b>Oxidizer</b> and <b>Ammonia</b> react to produce <b>MonoPropellant</b> and <b>Water</b>.
 			tech = advScienceTech
 
 			MODULE


### PR DESCRIPTION
* Added FOR[AirlineKuisine] Allows support patch in Kerbalism's support folder to detect when AirlineKuisine is installed. Kerbalism's support patch adds a number of things depending on what mods that Kerbalism offers support for are installed, such as LH2 storage for CryoTanks etc.
* Fixed descriptions etc to match Kerbalisms latest changes.
* Added CO2 and Xenon Gas to pressurized tanks to match Kerbalisms tanks.
* Made changes to the Fuel cell to reflect Kerbalisms changes to the Fuel cell which is now configurable.
* There have been a number of new processes added to Kerbalism's Chemical Plant which I have imported.
* Kerbalism has a slot upgrade part that upgrades certain parts with an extra slot, added the recognition of the upgrade to the Chemical plant.
* Kerbalisms Greenhouse module has been changed to allow the Greenhouse to work like a scrubber, there have also been other changes that have been imported across.
* Mk2 Greenhouse habitat size set to reflect the Mk2 part size, Pressure control removed to provide more room for crops 😉
* Rebalanced the Mk2 Greenhouse to use figures representative of McDonalds Kentucky Fried Chicken supplied by Burger King and endorsed by Wendy's. Also included free fries... but I ate them 😋

Note that CO2 is no longer classed as a waste gas due to the greenhouse and some processes requiring it.