### PR TITLE
Remove MM config for MK2X & USI-LS

### DIFF
--- a/GameData/DeepSky/AirlineKuisine/dask_otherMM.cfg
+++ b/GameData/DeepSky/AirlineKuisine/dask_otherMM.cfg
@@ -132,33 +132,3 @@
 		}
 	}
 }
-	
-@PART[M2X_SmallLab]:NEEDS[USILifeSupport,Mk2Expansion]:AFTER[USILifeSupport]
-{
-	MODULE
-	{
-		name = ModuleLifeSupport
-	}
-
-	MODULE
-	{
-		name = ModuleLifeSupportRecycler
-		CrewCapacity = 2
-		RecyclePercent = .5
-		ConverterName = Life Support
-		tag = Life Support
-		StartActionName = Start Life Support
-		StopActionName = Stop Life Support
-
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 0.5
-		}
-	}
-
-	MODULE
-	{
-		name = USI_ModuleFieldRepair
-	}
-}


### PR DESCRIPTION
Mark 2 Expansion now has its own MM config for USI-LS which adds a recycler to the Mk2 Lab, so this patch now causes two recyclers to be added to MK2X Sci lab.

From what I can tell, MK2X doesn't have a MM patch for Snacks, so I haven't removed that.